### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through a stack trace

### DIFF
--- a/backend/src/routes/user.js
+++ b/backend/src/routes/user.js
@@ -13,7 +13,8 @@ router.post('/register', async (req, res) => {
     await user.save();
     res.status(201).send(user);
   } catch (error) {
-    res.status(400).send(error);
+    console.error('Error during user registration:', error);
+    res.status(400).send('Registration failed');
   }
 });
 
@@ -28,7 +29,8 @@ router.post('/login', async (req, res) => {
     const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET);
     res.send({ token });
   } catch (error) {
-    res.status(400).send(error);
+    console.error('Error during user login:', error);
+    res.status(400).send('Login failed');
   }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/fgaletic/waterpolo_app/security/code-scanning/3](https://github.com/fgaletic/waterpolo_app/security/code-scanning/3)

In general, to fix this type of issue you should avoid sending raw exception objects or their stack traces to clients. Instead, send a generic error message and log the detailed error on the server (using `console.error` or a logging library). This preserves debuggability while preventing information disclosure.

For this specific file, the best minimal-impact fix is:

- In the `/login` route `catch` block (around lines 30–32), replace `res.status(400).send(error);` with:
  - A server-side log of the caught error (`console.error(error);` or similar).
  - A generic error response like `res.status(400).send('Login failed');` or a similar non‑revealing message.

Optionally, we should also align the `/register` route’s `catch` behavior with the same pattern, since `res.status(400).send(error);` there can also expose internal error details (for example, from database validation). Because both `catch` blocks use the same pattern and we are allowed to change snippets shown, we can safely make them both log the error and send a generic message, preserving behavior in terms of status codes and route structure while reducing information exposure.

Concretely:

- In `backend/src/routes/user.js`:
  - In the `/register` route `catch` (lines 15–17), change `res.status(400).send(error);` to log the error and send a generic message.
  - In the `/login` route `catch` (lines 30–32), change `res.status(400).send(error);` similarly.
- We can use `console.error` for logging and do not need new imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
